### PR TITLE
Add a Luigi task to index dataset metadata into Elasticsearch

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+elasticsearch:
+  image: elasticsearch:1.5.2
+  ports:
+   - "9200:9200"
+   - "9300:9300"
+  volumes:
+    - ./services/elasticsearch/config:/usr/share/elasticsearch/config

--- a/pipeline/requirements.txt
+++ b/pipeline/requirements.txt
@@ -1,3 +1,4 @@
 luigi==2.0.1
 -r scraper/requirements.txt
+-r tasks/requirements.txt
 

--- a/pipeline/tasks/index.py
+++ b/pipeline/tasks/index.py
@@ -1,0 +1,26 @@
+import luigi
+from luigi.contrib.esindex import CopyToIndex
+
+from scrape import ScrapeDatasets
+
+
+class IndexDatasets(CopyToIndex):
+    input_path = luigi.Parameter(default="data/scraper/datasets.json")
+
+    host = luigi.Parameter()
+    port = 9200
+    index = 'datasets'
+    doc_type = 'default'
+    purge_existing_index = True
+    marker_index_hist_size = 1
+    timeout = 30
+
+    def docs(self):
+        return (line for line in open(self.input_path))
+
+    def requires(self):
+        return ScrapeDatasets(output_path=self.input_path)
+
+if __name__ == '__main__':
+    task = IndexDatasets(host="192.168.99.100")
+    luigi.build([task], local_scheduler=True)

--- a/pipeline/tasks/requirements.txt
+++ b/pipeline/tasks/requirements.txt
@@ -1,0 +1,1 @@
+elasticsearch>=1.0.0,<2.0.0

--- a/services/elasticsearch/config/elasticsearch.yml
+++ b/services/elasticsearch/config/elasticsearch.yml
@@ -1,0 +1,6 @@
+################################### Cluster ###################################
+
+# Cluster name identifies your cluster for auto-discovery. If you're running
+# multiple clusters on the same network, make sure you're using unique names.
+#
+cluster.name: datagov_catalog


### PR DESCRIPTION
This PR also contains a Docker Compose config file to set up an Elasticsearch node where the data will be indexed.
