### PR TITLE
Add a simple recommender based on topic modeling to the pipeline

### DIFF
--- a/pipeline/pipeline.py
+++ b/pipeline/pipeline.py
@@ -1,6 +1,6 @@
 import luigi
 
-from tasks import scrape, index
+from tasks import scrape, index, recommend
 
 
 if __name__ == "__main__":

--- a/pipeline/recommender/.gitignore
+++ b/pipeline/recommender/.gitignore
@@ -1,0 +1,25 @@
+*.class
+*.log
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+# Project specific
+data/
+notebooks/
+neighbors/
+metastore_db/
+documents/
+lda-model/

--- a/pipeline/recommender/build.sbt
+++ b/pipeline/recommender/build.sbt
@@ -7,6 +7,7 @@ scalaVersion := "2.10.5"
 libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
   "org.apache.spark" %% "spark-mllib" % "1.6.0" % "provided",
+  "org.scalanlp" %% "chalk" % "1.3.2" exclude ("com.typesafe.sbt", "sbt-pgp"),
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "com.typesafe.akka" %% "akka-actor" % "2.3.4" % "test"
 )

--- a/pipeline/recommender/build.sbt
+++ b/pipeline/recommender/build.sbt
@@ -1,0 +1,20 @@
+name := "datagov-recommender"
+
+version := "0.0.1"
+
+scalaVersion := "2.10.5"
+
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
+  "org.apache.spark" %% "spark-mllib" % "1.6.0" % "provided",
+  "org.scalatest" %% "scalatest" % "2.2.4" % "test",
+  "com.typesafe.akka" %% "akka-actor" % "2.3.4" % "test"
+)
+
+resolvers ++= Seq(
+  "Akka Repository" at "http://repo.akka.io/releases/",
+  "Sonatype Snapshots" at "https://oss.sonatype.org/content/repositories/snapshots/",
+  "Sonatype Releases" at "https://oss.sonatype.org/content/repositories/releases/"
+)
+
+parallelExecution in Test := false

--- a/pipeline/recommender/build.sbt
+++ b/pipeline/recommender/build.sbt
@@ -8,6 +8,7 @@ libraryDependencies ++= Seq(
   "org.apache.spark" %% "spark-core" % "1.6.0" % "provided",
   "org.apache.spark" %% "spark-mllib" % "1.6.0" % "provided",
   "org.scalanlp" %% "chalk" % "1.3.2" exclude ("com.typesafe.sbt", "sbt-pgp"),
+  "com.github.karlhigley" %% "spark-neighbors" % "0.1.0",
   "org.scalatest" %% "scalatest" % "2.2.4" % "test",
   "com.typesafe.akka" %% "akka-actor" % "2.3.4" % "test"
 )

--- a/pipeline/recommender/project/assembly.sbt
+++ b/pipeline/recommender/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")

--- a/pipeline/recommender/project/plugins.sbt
+++ b/pipeline/recommender/project/plugins.sbt
@@ -1,0 +1,7 @@
+resolvers += "Sonatype OSS Releases" at "https://oss.sonatype.org/service/local/staging/deploy/maven2"
+
+addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.8.0")
+
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.3.5")

--- a/pipeline/recommender/src/main/scala/com/github/karlhigley/datagov/FindNeighbors.scala
+++ b/pipeline/recommender/src/main/scala/com/github/karlhigley/datagov/FindNeighbors.scala
@@ -1,0 +1,48 @@
+package com.github.karlhigley.datagov
+
+import org.apache.spark.{ SparkContext, SparkConf, Logging }
+import org.apache.spark.rdd.RDD
+import org.apache.spark.mllib.clustering.DistributedLDAModel
+import org.apache.spark.mllib.linalg.SparseVector
+import org.apache.spark.storage.StorageLevel
+
+import com.github.karlhigley.spark.neighbors.ANN
+
+object FindNeighbors extends Logging {
+  val serializerClasses: Array[Class[_]] = Array()
+
+  def main(args: Array[String]) {
+    val sparkConf = new SparkConf().setAppName("Data.gov Recommender")
+    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    sparkConf.registerKryoClasses(serializerClasses)
+    val sc = new SparkContext(sparkConf)
+
+    val config = new NeighborsConfiguration(args)
+
+    val distModel = DistributedLDAModel.load(sc, config.inputPath)
+    val documentTopics = distModel.topTopicsPerDocument(config.dimensions / 10)
+
+    val topicVectors =
+      documentTopics
+        .map {
+          case (id, indices, values) =>
+            (id.toInt, new SparseVector(config.dimensions, indices, values))
+        }
+        .repartition(256)
+        .persist(StorageLevel.MEMORY_AND_DISK_SER)
+
+    topicVectors.count()
+
+    val ann =
+      new ANN(config.dimensions, "cosine")
+        .setTables(config.tables)
+        .setSignatureLength(config.length)
+
+    val model = ann.train(topicVectors)
+    val neighbors = model.neighbors(config.neighbors)
+
+    neighbors.saveAsObjectFile(config.outputPath)
+
+    sc.stop()
+  }
+}

--- a/pipeline/recommender/src/main/scala/com/github/karlhigley/datagov/NeighborsConfiguration.scala
+++ b/pipeline/recommender/src/main/scala/com/github/karlhigley/datagov/NeighborsConfiguration.scala
@@ -1,0 +1,64 @@
+package com.github.karlhigley.datagov
+
+class NeighborsConfiguration(args: Array[String]) extends Serializable {
+  var inputPath = "./lda-model"
+  var outputPath = "./neighbors"
+  var dimensions = 100
+  var length = 256
+  var tables = 1
+  var neighbors = 10
+
+  parse(args.toList)
+
+  private def parse(args: List[String]): Unit = args match {
+    case ("--input" | "-i") :: path :: tail =>
+      inputPath = path
+      parse(tail)
+
+    case ("--output" | "-o") :: path :: tail =>
+      outputPath = path
+      parse(tail)
+
+    case ("--dimensions" | "-d") :: value :: tail =>
+      dimensions = value.toInt
+      parse(tail)
+
+    case ("--length" | "-l") :: value :: tail =>
+      length = value.toInt
+      parse(tail)
+
+    case ("--tables" | "-t") :: value :: tail =>
+      tables = value.toInt
+      parse(tail)
+
+    case ("--neighbors" | "-n") :: value :: tail =>
+      neighbors = value.toInt
+      parse(tail)
+
+    case ("--help" | "-h") :: tail =>
+      printUsageAndExit(0)
+
+    case _ =>
+  }
+
+  /**
+   * Print usage and exit JVM with the given exit code.
+   */
+  private def printUsageAndExit(exitCode: Int) {
+    val usage =
+      s"""
+      |Usage: spark-submit --class io.github.karlhigley.Summarizer <jar-path> [summarizer options]
+      |
+      |Options:
+      |   -i PATH, --input PATH          Relative path of input files (default: "./lda-model")
+      |   -o PATH, --output PATH         Relative path of output files (default: "./neighbors")
+      |   -d VALUE, --dimensions VALUE   Number of topic vector dimensions (default: 100)
+      |   -l VALUE, --length VALUE       Length of locality-sensitive hash signatures (default: 256)
+      |   -t VALUE, --tables VALUE       Number of hash tables (default: 1)
+      |   -n VALUE, --neighbors VALUE    Number of neighbors to return (default: 10)
+     """.stripMargin
+    System.err.println(usage)
+    System.exit(exitCode)
+  }
+
+}

--- a/pipeline/recommender/src/main/scala/com/github/karlhigley/datagov/TopicModelConfiguration.scala
+++ b/pipeline/recommender/src/main/scala/com/github/karlhigley/datagov/TopicModelConfiguration.scala
@@ -1,0 +1,52 @@
+package com.github.karlhigley.datagov
+
+class TopicModelConfiguration(args: Array[String]) {
+  var inputPath = "./datasets-json"
+  var outputPath = "./lda-model"
+  var topics = 100
+  var iterations = 20
+
+  parse(args.toList)
+
+  private def parse(args: List[String]): Unit = args match {
+    case ("--input" | "-i") :: path :: tail =>
+      inputPath = path
+      parse(tail)
+
+    case ("--output" | "-o") :: path :: tail =>
+      outputPath = path
+      parse(tail)
+
+    case ("--topics" | "-t") :: value :: tail =>
+      topics = value.toInt
+      parse(tail)
+
+    case ("--iterations" | "-r") :: value :: tail =>
+      iterations = value.toInt
+      parse(tail)
+
+    case ("--help" | "-h") :: tail =>
+      printUsageAndExit(0)
+
+    case _ =>
+  }
+
+  /**
+   * Print usage and exit JVM with the given exit code.
+   */
+  private def printUsageAndExit(exitCode: Int) {
+    val usage =
+      s"""
+      |Usage: spark-submit --class io.github.karlhigley.Summarizer <jar-path> [summarizer options]
+      |
+      |Options:
+      |   -i PATH, --input PATH          Relative path of input files (default: "./datasets-json")
+      |   -o PATH, --output PATH         Relative path of output files (default: "./lda-model")
+      |   -t VALUE, --topics VALUE       Number of topics to train (default: 100)
+      |   -r VALUE, --iterations VALUE   Maximum number of iterations (default: 20)
+     """.stripMargin
+    System.err.println(usage)
+    System.exit(exitCode)
+  }
+
+}

--- a/pipeline/recommender/src/main/scala/com/github/karlhigley/datagov/TrainTopicModel.scala
+++ b/pipeline/recommender/src/main/scala/com/github/karlhigley/datagov/TrainTopicModel.scala
@@ -1,0 +1,67 @@
+package com.github.karlhigley.datagov
+
+import chalk.text.analyze.PorterStemmer
+import chalk.text.tokenize.SimpleEnglishTokenizer
+
+import org.apache.spark.{ SparkContext, SparkConf, Logging }
+import org.apache.spark.mllib.clustering.{ LDA, DistributedLDAModel, LDAModel }
+import org.apache.spark.mllib.feature.HashingTF
+import org.apache.spark.mllib.linalg.SparseVector
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Row
+
+object TrainTopicModel extends Logging {
+  val serializerClasses: Array[Class[_]] = Array()
+
+  private def stem(token: String): String = {
+    PorterStemmer(token)
+  }
+
+  private def tokenize(texts: RDD[(Long, String)]): RDD[(Long, Array[String])] = {
+    val tokenizer = SimpleEnglishTokenizer()
+    val nonWord = "[^a-z]*".r
+
+    texts.mapValues(s =>
+      tokenizer(s.toLowerCase)
+        .toArray
+        .map(nonWord.replaceAllIn(_, ""))
+        .filter(_.length > 3)
+        .map(stem))
+  }
+
+  def main(args: Array[String]) {
+    val sparkConf = new SparkConf().setAppName("Data.gov Recommender")
+    sparkConf.set("spark.serializer", "org.apache.spark.serializer.KryoSerializer")
+    sparkConf.registerKryoClasses(serializerClasses)
+    val sc = new SparkContext(sparkConf)
+    val sqlContext = new org.apache.spark.sql.SQLContext(sc)
+
+    val config = new TopicModelConfiguration(args)
+
+    val corpus = sqlContext.read.json(config.inputPath)
+
+    val descriptions = corpus.select("notes").rdd.map {
+      case Row(notes: String) => notes
+      case _ => ""
+    }.zipWithIndex.map(_.swap).cache()
+
+    val tokens = tokenize(descriptions)
+
+    val hashingTF = new HashingTF()
+    val termFrequencies = tokens.mapValues(t => {
+      hashingTF.transform(t)
+    })
+
+    val ldaModel = new LDA()
+      .setK(config.topics)
+      .setMaxIterations(config.iterations)
+      .run(termFrequencies)
+
+    // Since LDAModel doesn't have a topTopicsPerDocument method,
+    // the model has to be converted to a DistributedLDAModel
+    // and saving/reloading is currently the only way to do that
+    ldaModel.save(sc, config.outputPath)
+
+    sc.stop()
+  }
+}

--- a/pipeline/tasks/recommend.py
+++ b/pipeline/tasks/recommend.py
@@ -1,0 +1,36 @@
+import sys
+
+import luigi
+import luigi.contrib.spark
+
+from scrape import ScrapeDatasets
+
+
+class TrainTopicModel(luigi.contrib.spark.SparkSubmitTask):
+    app = 'jars/datagov-recommender-assembly-0.0.1.jar'
+    entry_class = 'com.github.karlhigley.datagov.TrainTopicModel'
+
+    def app_options(self):
+        return ["--input", "data/scraper", "--output", "data/topic-model"]
+
+    def output(self):
+        return luigi.LocalTarget('lda-model')
+
+    def requires(self):
+        return ScrapeDatasets()
+
+
+class FindNeighbors(luigi.contrib.spark.SparkSubmitTask):
+    app = 'jars/datagov-recommender-assembly-0.0.1.jar'
+    entry_class = 'com.github.karlhigley.datagov.FindNeighbors'
+
+    def output(self):
+        return luigi.LocalTarget('neighbors')
+
+    def requires(self):
+        return TrainTopicModel()
+
+
+if __name__ == "__main__":
+    task = FindNeighbors()
+    luigi.build([task], local_scheduler=True)


### PR DESCRIPTION
This adds simple batch computation of recommendations to the pipeline. Computing recommendations has two steps:
- Train an LDA topic model on dataset descriptions
- Find approximate nearest neighbors among the resulting topic vectors

For now, the Spark batch jobs output an object file containing neighbors for each point. In order to integrate these recommendations into the web app, it may be helpful to output a file format that would be easier to ingest into a database or into Elasticsearch (for example) without using Spark. One option would be to output a JSON file and use Luigi's ES CopyToIndex task.
